### PR TITLE
Add support for docker deployment

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,44 @@
+# Deploy phagrancy with docker
+
+Example how to run phagrancy app, on-premise Vagrant cloud, with docker.
+Two containers phagrancy-nginx and phagrancy-php-fpm are used.
+
+## Prepare a certificate and private key for the nginx web-server
+
+    mkdir nginx/certs
+    openssl \
+        req \
+        -nodes \
+        -x509 \
+        -newkey rsa:4096 \
+        -keyout nginx/certs/phagrancy.local.key \
+        -out nginx/certs/phagrancy.local.crt \
+        -days 365 \
+        -subj "/C=UA/L=Kyiv/O=Company name/OU=IT/CN=phagrancy.local"
+
+## Build nginx and php-fpm docker images
+
+    docker build -t phagrancy-nginx:latest nginx
+    docker build -t phagrancy-php-fpm:latest php-fpm
+
+## Prepare .env_phagrancy configuration file
+
+See docs [wiki/.env-Configuration-File](https://github.com/dlundgren/phagrancy/wiki/.env-Configuration-File).
+We can not use a phagrancy .env file alongside with docker-compose.yml
+because docker-compose loads startup environment variables from .env file.
+
+It is supposed that `storage_path=boxes`, this path will be mounted into
+php-fpm docker container. See [docker-compose.yml](docker-compose.yml).
+
+php-fpm is running with user:group `www-data:www-data`. Change file's owner:
+
+    chown 33:33 .env_phagrancy
+
+## Create a directory to store vagrant boxes
+
+    mkdir boxes
+    chown 33:33 boxes
+
+## Start phagrancy docker containers
+
+    docker-compose up

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  nginx:
+    image: phagrancy-nginx:latest
+    container_name: phagrancy-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      phagrancy:
+
+  php-fpm:
+    image: phagrancy-php-fpm:latest
+    container_name: phagrancy-php-fpm
+    volumes:
+      - "./.env_phagrancy:/srv/phagrancy/.env"
+      - "./boxes:/srv/phagrancy/boxes"
+    networks:
+      phagrancy:
+
+networks:
+  phagrancy:
+    driver: bridge

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,20 @@
+FROM composer:1.9.0 as composer
+
+RUN git clone https://github.com/dlundgren/phagrancy.git \
+  && cd phagrancy \
+  && composer install \
+  && rm -rvf .git .gitignore .travis.yml
+
+FROM nginx:1.16.1
+
+COPY --from=composer /app/phagrancy /srv/phagrancy
+COPY nginx.conf /etc/nginx/nginx-phagrancy.conf
+COPY certs /etc/nginx/certs
+
+RUN chmod -R 0750 /etc/nginx/certs \
+  && chmod 0600 /etc/nginx/certs/*.crt \
+  && chmod 0400 /etc/nginx/certs/*.key \
+  && chown -R www-data. /srv/phagrancy
+
+WORKDIR /srv/phagrancy
+ENTRYPOINT ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx-phagrancy.conf"]

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,64 @@
+daemon off;
+worker_processes 2;
+
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    server_tokens   off;
+    keepalive_timeout  65;
+    gzip  on;
+
+    server {
+      listen         80;
+      server_name    phagrancy.local;
+      return         301 https://$server_name$request_uri;
+    }
+
+    server {
+      listen 443 ssl http2;
+      server_name phagrancy.local;
+      ssl_certificate /etc/nginx/certs/phagrancy.local.crt;
+      ssl_certificate_key /etc/nginx/certs/phagrancy.local.key;
+      ssl_protocols TLSv1.1 TLSv1.2;
+      ssl_ciphers HIGH:!aNULL:!MD5;
+      ssl_prefer_server_ciphers on;
+      ssl_session_cache   shared:SSL:20m;
+      ssl_session_timeout 10m;
+
+      root /srv/phagrancy/web;
+      index index.php index.html;
+      error_log /dev/stdout;
+      access_log /dev/stdout main;
+      client_max_body_size 7000m;
+
+      location / {
+          client_max_body_size 7G;
+          try_files $uri $uri/ /index.php$is_args$args;
+      }
+
+      location ~ [^/]\.php(/|$) {
+          fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+          if (!-f $document_root$fastcgi_script_name) {
+                  return 404;
+          }
+
+          fastcgi_pass phagrancy-php-fpm:9000;
+          include fastcgi_params;
+          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      }
+    }
+}

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,0 +1,5 @@
+FROM phagrancy-nginx:latest as nginx
+
+FROM php:7.3-fpm-buster
+
+COPY --from=nginx /srv/phagrancy /srv/phagrancy


### PR DESCRIPTION
Add support to run **phagrancy** in the docker containers: nginx and php-fpm are used to serve an application.

Closes #7 