### PR TITLE
Prevent overwriting existing boxes - fixes #3

### DIFF
--- a/src/Action/Api/Scope/Box/Upload.php
+++ b/src/Action/Api/Scope/Box/Upload.php
@@ -58,6 +58,13 @@ class Upload
 
 		extract($params);
 		$box = $this->boxes->ofNameInScope($name, $scope);
+		$path = "{$this->uploadPath}/{$box->path()}/{$version}/";
+
+		// If box with same version and provider already exists prevent overwriting
+		if (file_exists("$path/{$provider}.box")) {
+			return new Response\NotFound();
+		}
+
 		if ($box) {
 			if (!file_exists("{$this->uploadPath}/tmp")) {
 				mkdir("{$this->uploadPath}/tmp", 0755, true);
@@ -73,7 +80,6 @@ class Upload
 			fclose($to);
 
 			// make sure it exists
-			$path = "{$this->uploadPath}/{$box->path()}/{$version}/";
 			if (!file_exists($path)) {
 				mkdir($path, 0755, true);
 			}

--- a/src/Action/Scope/Index.php
+++ b/src/Action/Scope/Index.php
@@ -38,7 +38,7 @@ class Index
 	public function __invoke(ServerRequestInterface $request)
 	{
 		$params = $this->input->validate($request->getAttribute('route')->getArguments());
-		$scope   = $this->repository->ofName($params['scope']);
+		$scope  = $this->repository->ofName($params['scope'] ?? '');
 
 		if (!$scope) {
 			return new Response\NotFound();


### PR DESCRIPTION
This PR prevents uploading a box version which is already present.